### PR TITLE
fix(tts): allow discovery of system TTS engines via manifest queries

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,14 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- add twinstef 26/12/2025 -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.TTS_SERVICE" />
+        </intent>
+    </queries>
+    <!-- end -->
+
     <application
         android:name=".LlmHubApplication"
         android:enableOnBackInvokedCallback="true"


### PR DESCRIPTION
Add TTS_SERVICE intent query to AndroidManifest.xml so non-OEM TTS engines
(e.g. SherpaTTS) are discoverable and usable.

This fixes cases where TextToSpeech was forced to an OEM engine on some devices.